### PR TITLE
Fix native_libs.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        # required for auto-detection of auxiliary "native" libs
+        if not extdir.endswith(os.path.sep):
+            extdir += os.path.sep
+
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
 


### PR DESCRIPTION
When building additional, auxiliary libraries they should receive proper handling in "native_libs.txt". Surprisingly, this only happens when a trailing `/` is added.

Also, together with the primary module the (shared) libs will then go into the package directory instead of lying somewhere in the base path.

`native_libs.txt` also takes care, that these auxiliary, non-python, "native" libs are properly deinstalled as well.

Additional `RPATH`/`RUNPATH` handling for auxiliary, "native" libs is likely needed. E.g. on Linux when placing them all in the same base path (`$ORIGIN` is not a bash variable) of the package:

```
            '-DCMAKE_INSTALL_RPATH=$ORIGIN',
            '-DCMAKE_BUILD_WITH_INSTALL_RPATH:BOOL=ON',
            '-DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=OFF',
```

while on Windows one can just keep a flat structure in the package, which will be in `%PATH%` for the primary module and its helper `.dll`s.

Larger project example: https://github.com/openPMD/openPMD-api/pull/240