### PR TITLE
PEP-518: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cmake>=3.1.0", "pybind11"]


### PR DESCRIPTION
Add a `pyproject.toml` by default which is the proper location for build system requirements these days in Python.

https://www.python.org/dev/peps/pep-0518/