### PR TITLE
`-A x64` is not applicable to all CMake generators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class CMakeBuild(build_ext):
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            if sys.maxsize > 2**32:
+            if sys.maxsize > 2**32 and os.getenv("CMAKE_GENERATOR") is None:
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:


### PR DESCRIPTION
The CMake Generator can be set using the env variable CMAKE_GENERATOR
and if NMake or Ninja is set, then this results in an error