### PR TITLE
update demo to include an external library dependency (eg, google re2)

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -54,6 +54,7 @@ jobs:
 
     - name: Install library deps with brew
       run: |
+        brew upgrade cmake
         brew install eigen
       if: startsWith(matrix.os, 'mac')
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Install library deps with brew
       run: |
-        brew install eigen3
+        brew install eigen
       if: startsWith(matrix.os, 'mac')
 
     - name: Install library deps with apt

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -45,6 +45,26 @@ jobs:
         echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
         echo "MSSdk=1" >> $GITHUB_ENV
 
+    - name: Install deps with vcpkg
+      run: |
+        echo $VCPKG_ROOT
+        vcpkg install re2:x64-windows
+        vcpkg integrate install
+      if: startsWith(matrix.os, 'win')
+
+    - name: Install deps with brew
+      run: |
+        brew install re2
+      if: startsWith(matrix.os, 'mac')
+
+    - name: Install re2 deps with apt
+      if: runner.os == 'Linux'           
+      run: |
+        sudo apt-get -qq update
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository -y -s ppa:nerdboy/embedded
+        sudo apt-get install -y libre2-dev
+
     - name: Build and install
       run: pip install --verbose .
 

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -45,17 +45,22 @@ jobs:
         echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
         echo "MSSdk=1" >> $GITHUB_ENV
 
+    - name: Update vcpkg
+      run: |
+        cd C:\vcpkg
+        git pull
+        .\\bootstrap-vcpkg.bat
+      if: startsWith(matrix.os, 'win')
+
     - name: Install library deps with vcpkg
       run: |
-        echo $VCPKG_ROOT
         vcpkg install eigen3:x64-windows
         vcpkg integrate install
       if: startsWith(matrix.os, 'win')
 
     - name: Install library deps with brew
       run: |
-        brew upgrade cmake
-        brew install eigen
+        brew install -s eigen
       if: startsWith(matrix.os, 'mac')
 
     - name: Install library deps with apt

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -45,25 +45,23 @@ jobs:
         echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
         echo "MSSdk=1" >> $GITHUB_ENV
 
-    - name: Install deps with vcpkg
+    - name: Install library deps with vcpkg
       run: |
         echo $VCPKG_ROOT
-        vcpkg install re2:x64-windows
+        vcpkg install eigen3:x64-windows
         vcpkg integrate install
       if: startsWith(matrix.os, 'win')
 
-    - name: Install deps with brew
+    - name: Install library deps with brew
       run: |
-        brew install re2
+        brew install eigen3
       if: startsWith(matrix.os, 'mac')
 
-    - name: Install re2 deps with apt
+    - name: Install library deps with apt
       if: runner.os == 'Linux'           
       run: |
         sudo apt-get -qq update
-        sudo apt-get install -y software-properties-common
-        sudo add-apt-repository -y -s ppa:nerdboy/embedded
-        sudo apt-get install -y libre2-dev
+        sudo apt-get install -y libeigen3-dev
 
     - name: Build and install
       run: pip install --verbose .

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,6 +54,11 @@ jobs:
 
     - uses: actions/setup-python@v2
 
+    - name: Install library deps with apt
+      run: |
+	sudo apt-get -qq update
+        sudo apt-get install -y libeigen3-dev
+
     - name: Install cibuildwheel
       run: python -m pip install cibuildwheel==1.6.3
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,21 @@
 cmake_minimum_required(VERSION 3.4...3.18)
 project(cmake_example)
 
+find_package(re2 CONFIG REQUIRED)
+#find_path(HAVE_TOP_LEVEL_RE2_HEADER NAMES re2.h)
+
+find_package(Threads REQUIRED)
+
 add_subdirectory(pybind11)
 pybind11_add_module(cmake_example src/main.cpp)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a
 # define (VERSION_INFO) here.
 target_compile_definitions(cmake_example PRIVATE VERSION_INFO=${EXAMPLE_VERSION_INFO})
+
+target_compile_features(cmake_example INTERFACE cxx_std_11)
+target_link_libraries(cmake_example PRIVATE re2::re2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.4...3.18)
 project(cmake_example)
 
-find_package(re2 CONFIG REQUIRED)
-#find_path(HAVE_TOP_LEVEL_RE2_HEADER NAMES re2.h)
-
+find_package(Eigen3 CONFIG REQUIRED)
 find_package(Threads REQUIRED)
 
 add_subdirectory(pybind11)
@@ -18,4 +16,4 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 target_compile_definitions(cmake_example PRIVATE VERSION_INFO=${EXAMPLE_VERSION_INFO})
 
 target_compile_features(cmake_example INTERFACE cxx_std_11)
-target_link_libraries(cmake_example PRIVATE re2::re2)
+target_link_libraries(cmake_example PRIVATE Eigen3::Eigen)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <pybind11/pybind11.h>
+#include <re2/re2.h>
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <pybind11/pybind11.h>
-#include <re2/re2.h>
 
 #define STRINGIFY(x) #x
 #define MACRO_STRINGIFY(x) STRINGIFY(x)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+[tox]
+envlist = py3{6,7,8,9}
+skip_missing_interpreters = true
+
+[tox:travis]
+3.6 = py36
+3.7 = py37
+3.8 = py38
+3.9 = py39
+
+[testenv]
+passenv = CI PYTHON CC CXX
+
+deps =
+    pip>=19.0.1
+    wheel
+
+commands =
+    pip install .
+    python tests/test.py
+    #py.test . --cov --cov-report term-missing
+    # codecov
+
+[testenv:deploy]
+passenv = CI PYTHON CC CXX
+
+deps =
+    pip>=19.0.1
+    wheel
+
+commands =
+    python setup.py sdist
+    python setup.py bdist_wheel


### PR DESCRIPTION
This works, but only includes a header file and requires re2-config.cmake  (I couldn't make it find a random non-cmake lib, so I had to respin the gentoo ebuild to use cmake so it installed the .cmake files)
