### PR TITLE
chore: cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,21 +23,6 @@ class CMakeExtension(Extension):
 
 
 class CMakeBuild(build_ext):
-    def run(self):
-        # This is optional - will print a nicer error if CMake is missing.
-        # Since we force CMake via PEP 518 in the pyproject.toml, this should
-        # never happen and this whole method can be removed in your code if you
-        # want.
-        try:
-            subprocess.check_output(["cmake", "--version"])
-        except OSError:
-            msg = "CMake missing - probably upgrade to a newer version of Pip?"
-            raise RuntimeError(msg)
-
-        # To support Python 2, we have to avoid super(), since distutils is all
-        # old-style classes.
-        build_ext.run(self)
-
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ PLAT_TO_CMAKE = {
 
 
 # A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
 class CMakeExtension(Extension):
     def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
@@ -97,6 +99,8 @@ class CMakeBuild(build_ext):
         )
 
 
+# The information here can also be placed in setup.cfg - better separation of
+# logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="cmake_example",
     version="0.0.1",


### PR DESCRIPTION
Minor touchup based on usage. Dropping the explicit CMake check, as
pyproject.toml means that it's rarely missing, and if it is, you get a
reasonable error anyway.


- fix: drop unneeded function
- docs: add some notes
