### PR TITLE
ci: remove 2.7 Windows (no longer provided by Microsoft

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,10 +48,6 @@ jobs:
         submodules: true
 
     - uses: pypa/cibuildwheel@v1.12.0
-      env:
-        # Python 2.7 on Windows requires a workaround for C++11 support,
-        # built separately below
-        CIBW_SKIP: cp27-win*
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -62,49 +58,9 @@ jobs:
       with:
         path: wheelhouse/*.whl
 
-
-  # Windows 2.7 (requires workaround for MSVC 2008 replacement)
-  build_win27_wheels:
-    name: Py 2.7 wheels on Windows
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-
-    - uses: ilammy/msvc-dev-cmd@v1
-
-    - name: Build 64-bit wheel
-      uses: pypa/cibuildwheel@v1.12.0
-      env:
-        CIBW_BUILD: cp27-win_amd64
-        DISTUTILS_USE_SDK: 1
-        MSSdk: 1
-
-    - uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: x86
-
-    - name: Build 32-bit wheel
-      uses: pypa/cibuildwheel@v1.12.0
-      env:
-        CIBW_BUILD: cp27-win32
-        DISTUTILS_USE_SDK: 1
-        MSSdk: 1
-
-    - name: Verify clean directory
-      run: git diff --exit-code
-      shell: bash
-
-    - uses: actions/upload-artifact@v2
-      with:
-        path: wheelhouse/*.whl
-
-
   upload_all:
     name: Upload if release
-    needs: [build_wheels, build_win27_wheels, build_sdist]
+    needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 


### PR DESCRIPTION
This was removed some time ago - MS doesn't provide the download anymore, so was a no-op.
