### PR TITLE
feat: support Universal2 wheels

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ install:
     git submodule update -q --init --recursive
     if ($env:PLATFORM -eq "x64") { $env:PYTHON = "$env:PYTHON-x64" }
     $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
-    python -m pip install --disable-pip-version-check --upgrade --no-warn-script-location pip build
+    python -m pip install --disable-pip-version-check --upgrade --no-warn-script-location pip build pytest
 build_script:
 - ps: |
     python -m build -s
@@ -25,4 +25,4 @@ build_script:
     python -m pip install --verbose cmake_example-0.0.1.tar.gz
     cd ..
 test_script:
-- ps: python tests\test.py
+- ps: python -m pytest

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -35,7 +35,7 @@ jobs:
           channel-priority: strict
 
       - name: Prepare
-        run: conda install conda-build conda-verify
+        run: conda install conda-build conda-verify pytest
 
       - name: Build
         run: conda build conda.recipe
@@ -44,4 +44,4 @@ jobs:
         run: conda install -c ${CONDA_PREFIX}/conda-bld/ cmake_example
 
       - name: Test
-        run: python tests/test.py
+        run: python -m pytest

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -46,7 +46,7 @@ jobs:
         echo "MSSdk=1" >> $GITHUB_ENV
 
     - name: Build and install
-      run: pip install --verbose .
+      run: pip install --verbose .[test]
 
     - name: Test
-      run: python tests/test.py
+      run: python -m pytest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,8 @@ on:
       - published
 
 env:
-  CIBW_TEST_COMMAND: python {project}/tests/test.py
+  CIBW_TEST_COMMAND: pytest {project}/tests
+  CIBW_TEST_EXTRAS: test
 
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -52,6 +52,7 @@ jobs:
         # Python 2.7 on Windows requires a workaround for C++11 support,
         # built separately below
         CIBW_SKIP: cp27-win*
+        CIBW_ARCHS_MACOS: auto universal2
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,6 +53,9 @@ jobs:
         # built separately below
         CIBW_SKIP: cp27-win*
         CIBW_ARCHS_MACOS: auto universal2
+        CIBW_TEST_SKIP: "*universal2:arm64"
+        CIBW_TEST_EXTRAS: test
+        CIBW_TEST_COMMAND: pytest {project}/tests
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,12 +24,14 @@ requirements:
 
 
 test:
+  requires:
+    - pytest
   imports:
     - cmake_example
   source_files:
     - tests
   commands:
-    - python tests/test.py
+    - python -m pytest
 
 about:
   summary: A CMake example project built with pybind11.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "ninja; sys_platform != 'win32'",
+    "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
     "cmake>=3.12",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@
 ignore = E203, E231, E501, W503, B950
 select = C,E,F,W,B,B9
 exclude = docs/conf.py
+
+[tool:pytest]
+addopts = -ra
+testpaths =
+    tests

--- a/setup.py
+++ b/setup.py
@@ -118,5 +118,5 @@ setup(
     ext_modules=[CMakeExtension("cmake_example")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    extras_require=["pytest"],
+    extras_require={'test': ["pytest"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,12 @@ class CMakeBuild(build_ext):
             # Users can override the generator with CMAKE_GENERATOR in CMake
             # 3.15+.
             if not cmake_generator:
-                cmake_args += ["-GNinja"]
+                try:
+                    import ninja  # noqa: F401
+
+                    cmake_args += ["-GNinja"]
+                except ImportError:
+                    pass
 
         else:
 
@@ -118,5 +123,5 @@ setup(
     ext_modules=[CMakeExtension("cmake_example")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    extras_require={'test': ["pytest"]},
+    extras_require={"test": ["pytest"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
+import re
 import subprocess
+import sys
 
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
@@ -79,6 +80,12 @@ class CMakeBuild(build_ext):
                 ]
                 build_args += ["--config", cfg]
 
+        if sys.platform.startswith("darwin"):
+            # Cross-compile support for macOS - respect ARCHFLAGS if set
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                cmake_args += ["-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
+
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
@@ -111,4 +118,5 @@ setup(
     ext_modules=[CMakeExtension("cmake_example")],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
+    extras_require=["pytest"],
 )

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import cmake_example as m
 
-assert m.__version__ == "0.0.1"
-assert m.add(1, 2) == 3
-assert m.subtract(1, 2) == -1
+def test_main():
+    assert m.__version__ == "0.0.1"
+    assert m.add(1, 2) == 3
+    assert m.subtract(1, 2) == -1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import cmake_example as m
 
+
 def test_main():
     assert m.__version__ == "0.0.1"
     assert m.add(1, 2) == 3


### PR DESCRIPTION
This fixes setup.py to handle ARCHFLAGS, and verified that it works for universal2 wheels (they are twice the size; also manually tested on an Apple Silicon machine).

Uses PyTest and enables testing when making wheels.