### PR TITLE
fix: pull ninja path if module installed

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 
   host:
     - python
-    - pip
+    - pip !=22.1.0
 
   run:
     - python

--- a/setup.py
+++ b/setup.py
@@ -62,11 +62,15 @@ class CMakeBuild(build_ext):
             # exported for Ninja to pick it up, which is a little tricky to do.
             # Users can override the generator with CMAKE_GENERATOR in CMake
             # 3.15+.
-            if not cmake_generator:
+            if not cmake_generator or cmake_generator == "Ninja":
                 try:
                     import ninja  # noqa: F401
 
-                    cmake_args += ["-GNinja"]
+                    ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
+                    cmake_args += [
+                        "-GNinja",
+                        f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}",
+                    ]
                 except ImportError:
                     pass
 


### PR DESCRIPTION
Same fix as https://github.com/scikit-build/scikit-build/pull/631. Closes #75.
