### PR TITLE
Fix incorrect letter case for Python_EXECUTABLE option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ class CMakeBuild(build_ext):
         # from Python.
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
-            f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
+            f"-DPython_EXECUTABLE={sys.executable}", # CMake variables are case sensitive
         ]
         build_args = []
         # Adding CMake arguments set as environment variable

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class CMakeBuild(build_ext):
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
-            f"-DPython_EXECUTABLE={sys.executable}", # CMake variables are case sensitive
+            f"-DPython_EXECUTABLE={sys.executable}",  # CMake variables are case sensitive
         ]
         build_args = []
         # Adding CMake arguments set as environment variable


### PR DESCRIPTION
CMake's variables [are case-sensitive](https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#variables).
In some cases, the full uppercased `PYTHON_EXECUTABLE` will not work and leads to compile failing (for example, causes NumPy not found)
[According to document](https://cmake.org/cmake/help/latest/module/FindPython3.html#artifacts-specification), it should be `Python_EXECUTABLE` (Although it looks weird).