### PR TITLE
add Matlab GHA workflow (with a struct-definition addition to the basic example)

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -38,9 +38,9 @@ jobs:
 
       - run: python -c "import cmake_example as m; m.AStruct()"
 
-      - run: |
-          echo "pybind11_type=type" > pybind11_builtins.py
-          echo "PYTHONPATH=." >> $GITHUB_ENV
+      #- run: |
+      #    echo "pybind11_type=type" > pybind11_builtins.py
+      #    echo "PYTHONPATH=." >> $GITHUB_ENV
 
       - uses: matlab-actions/setup-matlab@v0
         with:

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,0 +1,47 @@
+name: matlab
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+
+
+jobs:
+  matlab:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - run: |
+          echo "CC=gcc-9" >> $GITHUB_ENV
+          echo "CXX=g++-9" >> $GITHUB_ENV
+          VERBOSE=1 pip install --verbose -e .
+
+      - run: |
+          echo "m = py.importlib.import_module('cmake_example')" > test.m
+          echo "AStruct = m.AStruct" >> test.m
+          echo "AStruct()" >> test.m
+          cat test.m
+
+      - run: python -c "import cmake_example as m; m.AStruct()"
+
+      - uses: matlab-actions/setup-matlab@v0
+        with:
+          release: R2022a
+
+      - uses: matlab-actions/run-command@v0
+        with:
+          command: test

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -38,6 +38,10 @@ jobs:
 
       - run: python -c "import cmake_example as m; m.AStruct()"
 
+      - run: |
+          echo "pybind11_type=type" > pybind11_type.py
+          echo "PYTHONPATH=." >> $GITHUB_ENV
+
       - uses: matlab-actions/setup-matlab@v0
         with:
           release: R2022a

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -39,7 +39,7 @@ jobs:
       - run: python -c "import cmake_example as m; m.AStruct()"
 
       - run: |
-          echo "pybind11_type=type" > pybind11_type.py
+          echo "pybind11_type=type" > pybind11_builtins.py
           echo "PYTHONPATH=." >> $GITHUB_ENV
 
       - uses: matlab-actions/setup-matlab@v0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,11 @@ int add(int i, int j) {
     return i + j;
 }
 
+struct AStruct {
+    AStruct() {
+    }
+};
+
 namespace py = pybind11;
 
 PYBIND11_MODULE(cmake_example, m) {
@@ -34,6 +39,8 @@ PYBIND11_MODULE(cmake_example, m) {
 
         Some other explanation about the subtract function.
     )pbdoc");
+
+    py::class_<AStruct>(m, "AStruct").def(py::init<>());
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(cmake_example, m) {
         Some other explanation about the subtract function.
     )pbdoc");
 
-    py::class_<AStruct>(m, "AStruct").def(py::init<>());
+    py::class_<AStruct>(m, "AStruct", py::metaclass((PyObject *) &PyType_Type)).def(py::init<>());
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,10 @@ struct AStruct {
     AStruct() {
     }
 };
+struct BStruct {
+    BStruct(AStruct &a) {
+    }
+};
 
 namespace py = pybind11;
 
@@ -41,6 +45,7 @@ PYBIND11_MODULE(cmake_example, m) {
     )pbdoc");
 
     py::class_<AStruct>(m, "AStruct", py::metaclass((PyObject *) &PyType_Type)).def(py::init<>());
+    py::class_<BStruct>(m, "BStruct", py::metaclass((PyObject *) &PyType_Type)).def(py::init<AStruct&>());
 
     m.def("fun", [](AStruct &a) { return 44; }, "doc", py::arg("a") );
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,8 @@ PYBIND11_MODULE(cmake_example, m) {
 
     py::class_<AStruct>(m, "AStruct", py::metaclass((PyObject *) &PyType_Type)).def(py::init<>());
 
+    m.def("fun", [](AStruct &a) { return 44; } );
+
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ PYBIND11_MODULE(cmake_example, m) {
 
     py::class_<AStruct>(m, "AStruct", py::metaclass((PyObject *) &PyType_Type)).def(py::init<>());
 
-    m.def("fun", [](AStruct &a) { return 44; } );
+    m.def("fun", [](AStruct &a) { return 44; }, "doc", py::arg("a") );
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -9,3 +9,4 @@ def test_main():
     a = m.AStruct()
     assert a is not None
     m.fun(a)
+    b = m.BStruct(a)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,3 +5,4 @@ def test_main():
     assert m.__version__ == "0.0.1"
     assert m.add(1, 2) == 3
     assert m.subtract(1, 2) == -1
+    assert m.AStruct() is not None

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,4 +5,7 @@ def test_main():
     assert m.__version__ == "0.0.1"
     assert m.add(1, 2) == 3
     assert m.subtract(1, 2) == -1
-    assert m.AStruct() is not None
+
+    a = m.AStruct()
+    assert a is not None
+    m.fun(a)


### PR DESCRIPTION
This PR adds a GHA workflow exemplifying usage of pybind11-built Python package from the Matlab Python interface.
The GHA uses the https://github.com/matlab-actions/setup-matlab action to enable access to licensed Matlab.

It shows that:
- on the one hand, the module is accessible and things like functions do work
- on the other hand, instantiating a class fails with:
```
  Cannot find class 'py.pybind11_builtins.pybind11_type'.
```

This issue has been reported at:
- https://github.com/pybind/pybind11/issues/3945
- https://www.mathworks.com/matlabcentral/answers/2031219-matlab-fails-to-run-python-built-with-pybind