### PR TITLE
Move pybind11 from submodule to pyproject.toml:build-system.requires.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "pybind11"]
-    path = pybind11
-    url = https://github.com/pybind/pybind11.git
-    branch = master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     - id: mypy
       files: "setup.py"
       args: []
-      additional_dependencies: [types-setuptools]
+      additional_dependencies: [types-setuptools, pybind11]
 
 # Changes tabs to spaces
 - repo: https://github.com/Lucas-C/pre-commit-hooks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4...3.18)
 project(cmake_example)
 
-add_subdirectory(pybind11)
+find_package(pybind11)
 pybind11_add_module(cmake_example src/main.cpp)
 
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
-include README.md LICENSE pybind11/LICENSE
-graft pybind11/include
-graft pybind11/tools
+include README.md LICENSE
 graft src
 global-include CMakeLists.txt *.cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "wheel",
     "ninja",
     "cmake>=3.12",
+    "pybind11>=2.9.2",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
+from pybind11 import get_cmake_dir
+
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {
     "win32": "Win32",
@@ -46,6 +48,7 @@ class CMakeBuild(build_ext):
         # from Python.
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
+            f"-Dpybind11_DIR={get_cmake_dir()}",
             f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={cfg}",  # not used on MSVC, but no harm
         ]

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+from pybind11 import get_cmake_dir
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
-
-from pybind11 import get_cmake_dir
 
 # Convert distutils Windows platform specifiers to CMake -A arguments
 PLAT_TO_CMAKE = {


### PR DESCRIPTION
Since we can specify setup dependencies in pyproject.toml, pybind11 could be added here instead of placed directly under the root of the repo, which make the repo structure more compact. And the path of pybind11 cmake config could be set by pybind11_DIR in setup.py.
