### PR TITLE
ci: macos-latest is changing to macos-14 ARM runners

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-13]
         python-version: ["3.8", "3.10"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-13]
+        platform: [ubuntu-latest, windows-latest, macos-12]
         python-version: ["3.8", "3.10"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-latest]
+        platform: [windows-latest, macos-13, ubuntu-latest]
         python-version: ["3.7", "3.11"]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos